### PR TITLE
Code improvements for reliability

### DIFF
--- a/src/win-e.ahk
+++ b/src/win-e.ahk
@@ -1,14 +1,21 @@
 #e::FocusFileExplorer()
 
 FocusFileExplorer() {
-   for Window in ComObjCreate("Shell.Application").Windows
-      continue
-   until Window.Name == "File Explorer" && hWnd := Window.hwnd
-   if hWnd
+   ran := 0
+   WinGet, ids, List, ahk_class CabinetWClass
+   Loop, %ids%
    {
-      WinActivate, ahk_id %hWnd%
-      Send, ^t
+      this_id := ids%A_Index%
+      WinActivate, ahk_id %this_id%
+      WinWaitActive, ahk_id %this_id%,, 2
+      active := WinActive(ahk_class CabinetWClass)
+      if (active != 0) {
+         send, ^t
+         ran := 1
+         break
+      }
    }
-   else
+   if (ran != 1){
       Run, % "explorer"
+   }
 }

--- a/src/win-e.ahk
+++ b/src/win-e.ahk
@@ -1,21 +1,20 @@
 #e::FocusFileExplorer()
 
 FocusFileExplorer() {
-   ran := 0
    WinGet, ids, List, ahk_class CabinetWClass
-   Loop, %ids%
-   {
-      this_id := ids%A_Index%
-      WinActivate, ahk_id %this_id%
-      WinWaitActive, ahk_id %this_id%,, 2
-      active := WinActive(ahk_class CabinetWClass)
-      if (active != 0) {
-         send, ^t
-         ran := 1
-         break
+   if (ids != 0){
+      Loop, %ids% {
+         this_id := ids%A_Index%
+         WinActivate, ahk_id %this_id%
+         WinWaitActive, ahk_id %this_id%,, 2
+         active := WinActive(ahk_class CabinetWClass)
+         if (active != 0) {
+            send, ^t
+            break
+         }
       }
    }
-   if (ran != 1){
+   else {
       Run, % "explorer"
    }
 }


### PR DESCRIPTION
- Fixed script not working on other windows locale (In my french windows installation, Window.Name did not return "File Explorer" but rather a french translation). This new version will work regardless of Windows language since it uses the class name instead.

- Added a line that waits for the explorer window to be active (with a limit of 2 seconds) before sending Ctrl+T. This fixes the script sometime opening a new browser window when the computer has some lag.

- Added a check of wether the current active window is the desired one, to avoid the same issue as above.

To make script locale agnostic, I had to make significant changes to the logic, hopefully you don't mind